### PR TITLE
Add note about NoErrorsPlugin in webpack 1

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ Next, enable hot reloading in your webpack config:
         // OccurenceOrderPlugin is needed for webpack 1.x only
         new webpack.optimize.OccurenceOrderPlugin(),
         new webpack.HotModuleReplacementPlugin(),
+        // Use NoErrorsPlugin for webpack 1.x
         new webpack.NoEmitOnErrorsPlugin()
     ]
     ```


### PR DESCRIPTION
As the OccurenceOrderPlugin has a note about webpack 1, I figured we should include a note about NoEmitOnErrorsPlugin for consistency.